### PR TITLE
Fix slf4j dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ dependencies {
     
     compile "org.slf4j:slf4j-api:1.7.25"
     compile "io.github.microutils:kotlin-logging:1.6.10"
-    runtime "org.slf4j:slf4j-simple:1.7.25"
+    runtimeOnly "org.slf4j:slf4j-simple:1.7.25"
     
     shade "net.java.dev.jna:jna:4.5.0"
     shadeInPlace files("libs")


### PR DESCRIPTION
Woops, I introduced slf4j-simple into the projects that depend on drpc4k, which of course wasn't my intention. This fixes it.